### PR TITLE
fix: Skip libatomic check on Nix-based systems

### DIFF
--- a/pear.js
+++ b/pear.js
@@ -158,9 +158,22 @@ function startDriveMonitor (updater) {
 
 function libatomicCheck () {
   try {
-    const output = require('child_process').execSync('ldconfig -p | grep libatomic', { stdio: 'pipe' }).toString()
-    return output.includes('libatomic.so')
+    // Check for NixOS environment
+    if (process.env.NIX_PROFILES || process.env.NIX_PATH) {
+      // On NixOS, just skip the check since libatomic is available through the stdenv
+      return true
+    }
+    
+    // For non-NixOS systems, use the original check
+    try {
+      const output = require('child_process').execSync('ldconfig -p | grep libatomic', { stdio: 'pipe' }).toString()
+      return output.includes('libatomic.so')
+    } catch (error) {
+      console.log('Error checking for libatomic:', error.message)
+      return false
+    }
   } catch (error) {
-    console.log('Error checking for libatomic:', error.message)
+    console.log('Error in libatomic check:', error.message)
+    return false
   }
 }


### PR DESCRIPTION
On NixOS and other Nix-based systems, Pear fails to install due to the libatomic check. This happens because the check uses ldconfig -p | grep libatomic, which doesn't work correctly in Nix environments, even when libatomic is actually available.

This PR adds detection for Nix environments using environment variables (NIX_PROFILES or NIX_PATH). When a Nix environment is detected, the check is bypassed since libatomic is typically available through the standard environment.

The PR also ensures proper return false behavior when errors occur in the check on non-Nix systems.

Tested on NixOS where the installation phase now completes successfully.

Note: There's still a separate issue with running the downloaded binaries on NixOS due to dynamic linking differences, but that's beyond the scope of this PR and would require additional work.